### PR TITLE
SR-DOCS-2030: update Graph Jupyter notebook to be more beginner-friendly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN yum update -y && \
     usermod -a -G aerospike ${NB_USER}
 
 # Install client, kernels, and extensions
-RUN python3 -m pip install --no-cache-dir aerospike gremlinpython "urllib3 <=1.26.15" jupyterlab graph-notebook && \
+RUN python3 -m pip install --no-cache-dir aerospike==13.0.0 gremlinpython "urllib3 <=1.26.15" jupyterlab graph-notebook && \
     curl -L -o ijava-kernel.zip "https://github.com/SpencerPark/IJava/releases/download/v1.3.0/ijava-1.3.0.zip" && \
     unzip ijava-kernel.zip -d ijava-kernel && \
     python3 ijava-kernel/install.py --sys-prefix && \

--- a/graph-notebook.ipynb
+++ b/graph-notebook.ipynb
@@ -7,10 +7,16 @@
    "source": [
     "## Welcome!\n",
     "\n",
-    "This notebook is intended to give new Aerospike Graph users an idea of how\n",
-    "graph databases work and what graph queries look like. The notebook is\n",
+    "This notebook is for new Aerospike Graph users, and it illustrates how graph\n",
+    "databases work and what graph queries look like. The notebook is\n",
     "fully editable, so you can change the queries and try out different ways\n",
-    "of accessing the data."
+    "of accessing the data.\n",
+    "\n",
+    "Aerospike Graph uses Aerospike Database as its underlying data store, with\n",
+    "Apache TinkerPop as its graph compute engine. For more information, see:\n",
+    "\n",
+    "- [Aerospike Database server documentation](https://docs.aerospike.com)\n",
+    "- [Apache TinkerPop documentation](https://tinkerpop.apache.org/docs/current/reference/)"
    ]
   },
   {
@@ -18,7 +24,7 @@
    "id": "365032c4-4c3b-497c-aabf-535a9ee31265",
    "metadata": {},
    "source": [
-    "### Configure the Gremlin server\n",
+    "### Start the Gremlin server\n",
     "\n",
     "This step starts the Gremlin server and connects it to an Aerospike database instance."
    ]
@@ -48,7 +54,7 @@
    "source": [
     "### Load data\n",
     "\n",
-    "This step reads a data file named `air-routes-small-latest.graphml` and loads into a graph database.\n",
+    "This step reads a data file named `air-routes-small-latest.graphml` and loads it into a graph database.\n",
     "The data file contains information about airports and flight routes in `graphml` format, with\n",
     "airports described in the vertices and flights between them described in the edges.\n",
     "\n",
@@ -106,7 +112,7 @@
    "id": "0492af4e-10d4-4763-af1f-dc2ae3df9ffb",
    "metadata": {},
    "source": [
-    "To get an idea of the kind of information the `airport` vertices contain, you can use the `properties()` method. It returns key-value pairs associated with each matching vertex."
+    "To get an idea of the kind of information the `airport` vertices contain, you can use the `properties()` method. This method returns key-value pairs associated with each matching vertex."
    ]
   },
   {
@@ -169,7 +175,7 @@
    "id": "832fe3ba-50ec-494c-a472-2328ec2815c3",
    "metadata": {},
    "source": [
-    "Gremlin has comparison operators for doing queries based on comparison criteria. The following query looks for flights longer than 4000 miles and returns a list of airports that have them."
+    "Gremlin has comparison operators for doing queries based on comparison criteria. The following query looks for flights longer than 4000 miles and returns a list of airports that have such flights."
    ]
   },
   {
@@ -223,7 +229,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.16"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/graph-notebook.ipynb
+++ b/graph-notebook.ipynb
@@ -2,15 +2,30 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "8f1be77b-6f87-4e58-b82b-f2f0eba0f49c",
+   "metadata": {},
+   "source": [
+    "## Welcome!\n",
+    "\n",
+    "This notebook is intended to give new Aerospike Graph users an idea of how\n",
+    "graph databases work and what graph queries look like. The notebook is\n",
+    "fully editable, so you can change the queries and try out different ways\n",
+    "of accessing the data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "365032c4-4c3b-497c-aabf-535a9ee31265",
    "metadata": {},
    "source": [
-    "### Configure the Gremlin server"
+    "### Configure the Gremlin server\n",
+    "\n",
+    "This step starts the Gremlin server and connects it to an Aerospike database instance."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "e0056755-1747-4d16-86b5-925f58fea5c4",
    "metadata": {
     "tags": []
@@ -28,10 +43,18 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71d4b3c0-bda9-4917-87d7-adc2bca04775",
+   "id": "051be243-399a-463b-afcf-80dce90ad717",
    "metadata": {},
    "source": [
-    "### Load data"
+    "### Load data\n",
+    "\n",
+    "This step reads a data file named `air-routes-small-latest.graphml` and loads into a graph database.\n",
+    "The data file contains information about airports and flight routes in `graphml` format, with\n",
+    "airports described in the vertices and flights between them described in the edges.\n",
+    "\n",
+    "**Note:** This data file contains a small subset of flight information. You can\n",
+    "find all the different versions of the publicly available air-routes dataset\n",
+    "[here](https://github.com/krlawrence/graph/tree/master/sample-data)."
    ]
   },
   {
@@ -50,9 +73,103 @@
   {
    "cell_type": "markdown",
    "id": "3975b75e-2c4b-45d2-90d4-ca1fb587a10b",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Run queries\n",
+    "\n",
+    "Gremlin uses the Groovy query language, which allows you to query your data and find\n",
+    "values, patterns, and relationships. You can also add and delete vertices and edges.\n",
+    "For a complete description of Gremlin and Groovy, see Kelvin Lawrence's tutorial\n",
+    "[Practical Gremlin](https://kelvinlawrence.net/book/PracticalGremlin.html).\n",
+    "\n",
+    "The following Gremlin query looks for all vertices with the `airport` label and returns a\n",
+    "count of how many it finds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "66410c47-dba8-462c-9855-d1d2a7d29938",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%gremlin\n",
+    "g.V().hasLabel('airport').count()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0492af4e-10d4-4763-af1f-dc2ae3df9ffb",
    "metadata": {},
    "source": [
-    "### Run queries"
+    "To get an idea of the kind of information the `airport` vertices contain, you can use the `properties()` method. It returns key-value pairs associated with each matching vertex."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "492db021-ec42-4b9b-9dee-e1363b123d2b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%gremlin\n",
+    "g.V().hasLabel('airport').properties()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "39233151-6ec3-481b-ab5d-12052bde20e6",
+   "metadata": {},
+   "source": [
+    "To get information from a specific vertex, you can look it up by one of its properties. The following query looks for the vertex with the airport code `DFW` and returns all its properties."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6af1db35-36b6-4451-b4b9-a6036d5143cb",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%gremlin\n",
+    "g.V().has('code','DFW').properties()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acb648b7-ef22-495e-93d5-45fe2c8263a6",
+   "metadata": {},
+   "source": [
+    "You can get information about the number and type of air routes into and out of an airport by querying its edges. The following query gets a count of the number of air routes leaving from the airport with code `SFO`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69b07edf-990d-405f-9f9b-0191f2ea1fb9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%gremlin\n",
+    " g.V().has('code','SFO').outE().count()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "832fe3ba-50ec-494c-a472-2328ec2815c3",
+   "metadata": {},
+   "source": [
+    "Gremlin has comparison operators for doing queries based on comparison criteria. The following query looks for flights longer than 4000 miles and returns a list of airports that have them."
    ]
   },
   {
@@ -64,8 +181,16 @@
    },
    "outputs": [],
    "source": [
-    "%%gremlin -p v,oute,inv\n",
-    "g.V().hasLabel('airport').outE().inV().path().by('code').by('dist').limit(5)"
+    "%%gremlin\n",
+    "g.E().has(\"dist\", P.gt(4000L)).inV().values(\"code\").dedup()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84fa2013-0b43-401a-8621-8d2090136b66",
+   "metadata": {},
+   "source": [
+    "Looking at all the edges associated with a particular airport vertex can tell you how many different flights go into or out of an airport. The following query lists all the cities you can fly to from Austin (AUS)."
    ]
   },
   {
@@ -77,8 +202,8 @@
    },
    "outputs": [],
    "source": [
-    "%%gremlin -g region -p v,inv\n",
-    "g.V().has('code','AUS').out().path().by(valueMap('region','code').order(local).by(keys))"
+    "%%gremlin\n",
+    "g.V().has('airport','code','AUS').out().values('city')"
    ]
   }
  ],


### PR DESCRIPTION
To run this new notebook:
- Grab the file `graph-notebook-steve.ipynb` from the Jira issue https://aerospike.atlassian.net/browse/DOCS-2030
- Open the page https://binder.aerospike.com/v2/gh/aerospike-examples/interactive-notebooks/sandbox-graph in a browser (it might take a minute to load)
- Use the upload icon (up arrow in the upper left of the page) to add the new notebook file
- Double click the new link after the file uploads 