### PR TITLE
Fix notebook for latest Trino connector 4.5.0 release

### DIFF
--- a/notebooks/presto/AerospikePrestoDemo.ipynb
+++ b/notebooks/presto/AerospikePrestoDemo.ipynb
@@ -5,70 +5,139 @@
    "metadata": {},
    "source": [
     "## Aerospike Connect for Presto Tutorial for Python\n",
-    "## Tested with Python 3.7, Java 11, Presto 343, Presto Connector (Beta), and PyHive 0.6.3"
+    "## Tested with Python 3.10.6, Java 17.0.5, Trino 435, Aerospike Trino Connector 4.5.0-431, and PyHive 0.18.3"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip3 install pyhive\n",
+    "!pip3 install requests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
    "metadata": {},
    "outputs": [],
    "source": [
     "from pyhive import presto\n",
+    "import requests\n",
+    "from requests.auth import HTTPBasicAuth\n",
     "presto_conn = presto.connect(\n",
     "    host='localhost',\n",
     "    port=8080,\n",
+    "    username='admin',\n",
     "    catalog='aerospike',\n",
-    "    schema='test'\n",
+    "    schema='test',\n",
+    "     requests_kwargs={\n",
+    "        'auth': HTTPBasicAuth('admin', '')\n",
+    "    }\n",
     ")\n",
     "presto_cursor=presto_conn.cursor()"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 2,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "presto_cursor.execute('SELECT * FROM test.write_set LIMIT 3')"
+    "## Following examples assumes that data was created using accompanying python notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Print infered schema of table `write_set`"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 71,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(234, 'Individual: 234', 33.568431516802406, 66363)\n",
-      "(13, 'Individual: 013', 25.752921531369164, 48610)\n",
-      "(79, 'Individual: 079', 25.16109674428971, 60357)\n"
+      "('__key', 'varchar', '', '')\n",
+      "('name', 'varchar', '', '')\n",
+      "('id', 'bigint', '', '')\n",
+      "('salary', 'bigint', '', '')\n",
+      "('age', 'double', '', '')\n"
      ]
     }
    ],
    "source": [
+    "query = \"DESCRIBE aerospike.test.write_set\"\n",
+    "presto_cursor.execute(query)\n",
+    "\n",
+    "# Fetch all the results\n",
+    "descriptions = presto_cursor.fetchall()\n",
+    "\n",
+    "# Print the descriptions\n",
+    "for col in descriptions:\n",
+    "    print(col)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Print all records of the table `write_set`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 72,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(None, 'Individual: 237', 237, 61928, 35.40459945502513)\n",
+      "(None, 'Individual: 145', 145, 81405, 45.02808010201396)\n",
+      "(None, 'Individual: 022', 22, 43865, 26.69338780386945)\n"
+     ]
+    }
+   ],
+   "source": [
+    "presto_cursor.execute('SELECT * FROM aerospike.test.write_set LIMIT 3')\n",
     "records = presto_cursor.fetchall()\n",
     "for row in records:\n",
     "    print(row)"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "presto_cursor.execute('select name from test.write_set where age>40 and age<45')"
+    "### Extract records of the table `write_set` by applying filters on the column `age`"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 76,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "('Individual: 176',)\n",
+      "('Individual: 153',)\n",
+      "('Individual: 111',)\n",
+      "('Individual: 118',)\n",
+      "('Individual: 151',)\n"
+     ]
+    }
+   ],
    "source": [
+    "presto_cursor.execute('select name from aerospike.test.write_set where age>40 and age<45 limit 5')\n",
     "records1 = presto_cursor.fetchall()\n",
     "for row in records1:\n",
     "    print(row)"
@@ -78,20 +147,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Refer to https://www.aerospike.com/docs/connect/access/presto/examples.html for more examples."
+    "### Refer to https://aerospike.com/docs/connect/trino/examples for more examples."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -105,7 +167,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Changed the description
- Fixed call to `presto.connect()` Api to work with Trino server 435
- Added some headers etc to beautify
- Updated the link to trino examples page